### PR TITLE
New AndroidManifest.xml for the merging tool

### DIFF
--- a/share/manifests/android/AndroidManifest.xml
+++ b/share/manifests/android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- BEGIN_INCLUDE(manifest) -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="{{android.package}}">
+    <uses-sdk android:minSdkVersion="9" />
     <application>
 
         <!-- For defold-sharing extension -->


### PR DESCRIPTION
This fix helps to avoid the situation when the merging tool add few permissions into final AndroidManifest.xml even if you don't have them into you AndroidManifest.xml files. 