### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/share/manifests/android/AndroidManifest.xml
+++ b/share/manifests/android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="{{android.package}}">
-    <uses-sdk android:minSdkVersion="9" />
+    <uses-sdk android:minSdkVersion="{{android.minimum_sdk_version}}" android:targetSdkVersion="{{android.target_sdk_version}}" />
     <application>
 
         <!-- For defold-sharing extension -->


### PR DESCRIPTION
Fixed AndroidManifest.xml, replaced minimum SDK version to avoid troubles with merge tool (when mergetool add permissions.