### PR TITLE
Update js APIs to latest Emscripten (3.1.55).

### DIFF
--- a/game.project
+++ b/game.project
@@ -4,7 +4,7 @@ version = 1.0.1
 write_log = 0
 custom_resources = example/videos
 dependencies#0 = https://github.com/britzl/gooey/archive/8.1.1.zip
-dependencies#1 = https://github.com/britzl/defold-screenshot/archive/1.8.1.zip
+dependencies#1 = https://github.com/britzl/defold-screenshot/archive/1.10.0.zip
 
 [bootstrap]
 main_collection = /example/example.collectionc

--- a/share/ext.manifest
+++ b/share/ext.manifest
@@ -9,10 +9,6 @@ platforms:
     context:
         frameworks: ["AVFoundation", "AppKit"]
 
-  armv7-ios:
-    context:
-        frameworks: ["AVFoundation", "UIKit"]
-
   arm64-ios:
     context:
         frameworks: ["AVFoundation", "UIKit"]

--- a/share/lib/web/lib_share.js
+++ b/share/lib/web/lib_share.js
@@ -104,4 +104,4 @@ var LibShare = {
 }
 
 autoAddDeps(LibShare, '$ShareLibrary');
-mergeInto(LibraryManager.library, LibShare);
+addToLibrary(LibShare);


### PR DESCRIPTION
Update js APIs to latest Emscripten (3.1.55).
Update defold-screenshot dependency to latest version.
Remove unused armv7-ios arch from manifest.

Relates to https://github.com/defold/defold/issues/6259